### PR TITLE
Fix Hex Character Range Detection for Escaped Unicode Characters

### DIFF
--- a/flatjson.go
+++ b/flatjson.go
@@ -373,9 +373,9 @@ func scanString(data []byte, i int) (Pos, error) {
 				}
 				for j, b := range data[to+1 : to+5] {
 					if b < '0' ||
-						(b > '9' && b < 'a') ||
-						(b > 'f' && b < 'A') ||
-						(b > 'F') {
+						(b > '9' && b < 'A') ||
+						(b > 'F' && b < 'a') ||
+						(b > 'f') {
 						return Pos{}, syntaxErr(to+j-2, unicodeNotFollowHex, nil)
 					}
 					to++

--- a/flatjson_test.go
+++ b/flatjson_test.go
@@ -296,6 +296,18 @@ func TestScanObjects(t *testing.T) {
 			WantPos:   Pos{5, 13},
 			WantFound: true,
 		},
+		{
+			Name:      "escaped unicode in string",
+			Data:      `{"hello":"world \u00E9"}`,
+			WantPos:   Pos{0, 24},
+			WantFound: true,
+			WantString: []tstring{
+				{name: `"hello"`, value: `"world \u00E9"`},
+			},
+			WantRaw: []traw{
+				{name: `"hello"`, raw: `"world \u00E9"`},
+			},
+		},
 
 		// errors
 		{
@@ -431,12 +443,17 @@ func TestScanObjects(t *testing.T) {
 			WantErrError:  expectValueButNoKnownType,
 			WantErrOffset: 10,
 		},
-
 		{
 			Name:          "no closing bracket at end of object",
 			Data:          `{"hello": "hello"   `,
 			WantErrError:  endOfDataNoClosingBracket,
 			WantErrOffset: 21,
+		},
+		{
+			Name:          "invalid unicode escape",
+			Data:          `{"hello": "world\uZZ99"}`,
+			WantErrError:  beginStringValueButError + ", " + unicodeNotFollowHex,
+			WantErrOffset: 10,
 		},
 	}
 


### PR DESCRIPTION
Hi Antoine,

I'm Caleb Lawson from Olo. You may have noticed our pull request (#1) last week. Unfortunately, we had to close the request so that we could follow our internal policies for FOSS contributions. We have since completed that process and have received approval to submit our contribution.

We would like to thank you for creating `flatjson` and `orderedjson`. The combined use of these libraries has helped us overcome limitations of golang's built-in JSON parsing for arbitrary objects. We specifically depend on `orderedjson` to maintain the field order of JSON payloads for the sake of human readability.

For a small percentage of JSON payloads that we process, we noticed that `flatjson` was failing to read payloads containing specific ranges of escaped Unicode characters. We took a closer look and noticed a problem with how the range of valid hexadecimal characters are currently defined in `flatjson`. [Unicode Latin alphabet uppercase characters have a lower numeric value than lowercase Latin alphabet characters](https://en.wikipedia.org/wiki/List_of_Unicode_characters). [This line was triggering a false positive for a syntax error in some cases](https://github.com/aybabtme/flatjson/blob/1fbd386705614b9b3695bde6559256df31135812/flatjson.go#L376). The character range between `9` and `a` includes all uppercase Latin alphabet characters.

The first commit, 6c59c5b9f9c914f51f14c6d7913a96bcea7cd67a, contains one test demonstrating the false positive syntax error and another test demonstrating a valid syntax error from the same code. The second commit, 8c1b5bbd26549c26dff68408b34b815078fff5eb, contains the updated character range, for which both of the tests pass.

Once this merges, we plan to make a contribution to `orderedjson` to update it to use the latest version of this package. Please let us know if there are any other ways we can help